### PR TITLE
Use the full container name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM docker.io/library/python:slim
 
 MAINTAINER Randy Pargman "randy.pargman@binarydefense.com"
 


### PR DESCRIPTION
Buildah isn't guaranteed to pull from docker.io. It always recommended to use the full name.

In this case it seems to work out fine. I have had issues in the past with this however.